### PR TITLE
Fix Skipping a commit for tagging and deployment exercise (11.16) - 2

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,12 +16,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
-      - name: should deploy and tag if not '#skip'
-        env:
-          NOT_SKIP: ${{ (github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')) }}
-        run: |
-          echo "DEPLOY_AND_TAG=${NOT_SKIP}" >> $GITHUB_ENV
-          echo "DEPLOY_AND_TAG set to ${NOT_SKIP}"
       - name: npm install
         run: npm install
       - name: lint
@@ -37,7 +31,7 @@ jobs:
           start: npm run start-prod
           wait-on: http://localhost:5000
       - uses: akhileshns/heroku-deploy@v3.12.12
-        if: env.DEPLOY_AND_TAG == 'true'
+        if: github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: 'infinite-falls-00428'
@@ -54,7 +48,7 @@ jobs:
           fetch-depth: 0
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@ce4b5ffa38e072fa7a901e417253c438fcc2ccce
-        if: env.DEPLOY_AND_TAG == 'true'
+        if: github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           NOT_SKIP: ${{ (github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')) }}
         run: |
           echo "DEPLOY_AND_TAG=${NOT_SKIP}" >> $GITHUB_ENV
+          echo "DEPLOY_AND_TAG set to ${NOT_SKIP}"
           echo "::set-output name=deploy::${NOT_SKIP}"
       - name: deploy if true
         if: env.DEPLOY_AND_TAG == 'true'
@@ -30,6 +31,7 @@ jobs:
     needs: [test_job_1]
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v2
       - name: deploy_and_tag output
         env:
           TEST_DEPLOY_AND_TAG: ${{ needs.test_job_1.outputs.deploy_and_tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,7 @@ jobs:
         env:
           JOINED_MESSAGES: ${{ join(github.event.commits.*.message) }}
         run: echo "$JOINED_MESSAGES"
-      - id: simple_deploy
-      - name: should deploy and tag if not '#skip'
+      - id: simple_deploy - should deploy and tag if not '#skip'
         env:
           NOT_SKIP: ${{ (github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')) }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test_job_1:
     runs-on: ubuntu-20.04
+    # set outputs for reusing data from one job on other jobs
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
     outputs:
       deploy_and_tag: ${{ steps.simple_deploy.outputs.deploy }}
     steps:
@@ -25,7 +27,7 @@ jobs:
           echo "DEPLOY_AND_TAG set to ${NOT_SKIP}"
           echo "::set-output name=deploy::${NOT_SKIP}"
       - name: deploy if true
-        if: env.DEPLOY_AND_TAG == 'true'
+        if: github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')
         run: echo "I deploy"
   test_job_2:
     needs: [test_job_1]
@@ -36,6 +38,7 @@ jobs:
         env:
           TEST_DEPLOY_AND_TAG: ${{ needs.test_job_1.outputs.deploy_and_tag }}
         run: echo "deploy and tag output < ${TEST_DEPLOY_AND_TAG} >"
+        # here is the deploy_and_tag output reused
       - name: use deploy and tag env
         if: ${{ needs.test_job_1.outputs.deploy_and_tag == 'true' }}
         run: echo "I tag"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           echo "DEPLOY_AND_TAG set to ${NOT_SKIP}"
           echo "::set-output name=deploy::${NOT_SKIP}"
       - name: deploy if true
-        if: github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')
+        if: env.DEPLOY_AND_TAG == 'true'
         run: echo "I should deploy"
   test_job_2:
     needs: [test_job_1]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           echo "::set-output name=deploy::${NOT_SKIP}"
       - name: deploy if true
         if: github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')
-        run: echo "I deploy"
+        run: echo "I should deploy"
   test_job_2:
     needs: [test_job_1]
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,22 +6,13 @@ on:
       - test-workflow
 
 jobs:
-  a_test_job:
+  test_job_1:
     runs-on: ubuntu-20.04
+    outputs:
+      deploy_and_tag: ${{ steps.simple_deploy.outputs.deploy }}
     steps:
+      - id: simple_deploy
       - uses: actions/checkout@v2
-      - name: gihub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: commits
-        env:
-          COMMITS: ${{ toJson(github.event.commits) }}
-        run: echo "$COMMITS"
-      - name: commit messages
-        env:
-          COMMIT_MESSAGES: ${{ toJson(github.event.commits.*.message) }}
-        run: echo "$COMMIT_MESSAGES"
       - name: joined commit messages
         env:
           JOINED_MESSAGES: ${{ join(github.event.commits.*.message) }}
@@ -31,7 +22,18 @@ jobs:
           NOT_SKIP: ${{ (github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')) }}
         run: |
           echo "DEPLOY_AND_TAG=${NOT_SKIP}" >> $GITHUB_ENV
-          echo "DEPLOY_AND_TAG set to ${NOT_SKIP}"
+          echo "::set-output name=deploy::${NOT_SKIP}"
       - name: deploy if true
         if: env.DEPLOY_AND_TAG == 'true'
-        run: echo "I deploy and tag"
+        run: echo "I deploy"
+  test_job_2:
+    needs: [test_job_1]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: deploy_and_tag output
+        env:
+          TEST_DEPLOY_AND_TAG: ${{ needs.test_job_1.outputs.deploy_and_tag }}
+        run: echo "deploy and tag output < ${TEST_DEPLOY_AND_TAG} >"
+      - name: use deploy and tag env
+        if: ${{ needs.test_job_1.outputs.deploy_and_tag == 'true' }}
+        run: echo "I tag"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           JOINED_MESSAGES: ${{ join(github.event.commits.*.message) }}
         run: echo "$JOINED_MESSAGES"
-      - id: simple_deploy - should deploy and tag if not '#skip'
+      - id: simple_deploy
         env:
           NOT_SKIP: ${{ (github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')) }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
           JOINED_MESSAGES: ${{ join(github.event.commits.*.message) }}
         run: echo "$JOINED_MESSAGES"
       - id: simple_deploy
+        name: should deploy and tag if not '#skip'
         env:
           NOT_SKIP: ${{ (github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')) }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     outputs:
       deploy_and_tag: ${{ steps.simple_deploy.outputs.deploy }}
     steps:
-      - id: simple_deploy
       - uses: actions/checkout@v2
       - name: joined commit messages
         env:
           JOINED_MESSAGES: ${{ join(github.event.commits.*.message) }}
         run: echo "$JOINED_MESSAGES"
+      - id: simple_deploy
       - name: should deploy and tag if not '#skip'
         env:
           NOT_SKIP: ${{ (github.event_name == 'push' && !contains(join(github.event.commits.*.message), '#skip')) }}


### PR DESCRIPTION
- Test the use of outputs for reusing data in different workflows
- Use raw conditionals for if on deploy and tag
- Remove use of env.DEPLOY_AND_TAG because it can't be shared between jobs
